### PR TITLE
UI improvements: hero section, responsive menu, Tully's-style header,…

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -21,8 +21,63 @@
     }
 </script>
 
-<!-- 背景オーバーレイ（メニュー外クリックで閉じる） -->
+<!-- 固定ヘッダーバー -->
+<header class="site-header">
+    <!-- ロゴ -->
+    <a href="{base}/" class="logo-link" onclick={closeMenu}>
+        <img src="{base}/images/icon.png" alt="微小夜行電灯" class="logo-img" />
+        <span class="logo-text">微小夜行電灯</span>
+    </a>
+
+    <!-- プライマリナビ（常時表示） -->
+    <nav class="primary-nav" aria-label="主要ナビゲーション">
+        <a href="{base}/map" class="primary-nav-item" onclick={closeMenu}>
+            <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+                <polyline points="9 22 9 12 15 12 15 22"/>
+            </svg>
+            <span>屋台貸し出し</span>
+        </a>
+        <a href="{base}/shop" class="primary-nav-item" onclick={closeMenu}>
+            <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="9" cy="21" r="1"/>
+                <circle cx="20" cy="21" r="1"/>
+                <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"/>
+            </svg>
+            <span>オンラインストア</span>
+        </a>
+
+        <!-- デスクトップ用その他のリンク -->
+        <a href="{base}/menu" class="desktop-nav-item" onclick={closeMenu}>メニュー</a>
+        <a href="{base}/company" class="desktop-nav-item" onclick={closeMenu}>事業内容</a>
+        <a href="{base}/directory" class="desktop-nav-item" onclick={closeMenu}>夜行人図鑑</a>
+        {#if $session}
+            <button class="desktop-nav-item desktop-auth-btn" onclick={handleSignOut}>ログアウト</button>
+        {:else}
+            <a href="{base}/auth" class="desktop-nav-item desktop-auth-link" onclick={closeMenu}>ログイン</a>
+        {/if}
+    </nav>
+
+    <!-- ハンバーガーボタン -->
+    <button
+        class="hamburger"
+        class:active={isMenuOpen}
+        onclick={toggleMenu}
+        aria-label={isMenuOpen ? 'メニューを閉じる' : 'メニューを開く'}
+        aria-expanded={isMenuOpen}
+    >
+        <span></span>
+        <span></span>
+        <span></span>
+    </button>
+</header>
+
+<!-- レイアウト用スペーサー（固定ヘッダーの高さ分） -->
+<div class="header-spacer" aria-hidden="true"></div>
+
+<!-- サイドメニュー（ハンバーガー展開時） -->
 {#if isMenuOpen}
+    <!-- 背景オーバーレイ -->
     <div
         class="menu-overlay"
         onclick={closeMenu}
@@ -31,244 +86,274 @@
         tabindex="-1"
         aria-label="メニューを閉じる"
     ></div>
-{/if}
 
-<header>
-    <button
-        class="hamburger"
-        class:active={isMenuOpen}
-        onclick={toggleMenu}
-        aria-label="メニュー"
-        aria-expanded={isMenuOpen}
-    >
-        <span></span>
-        <span></span>
-        <span></span>
-    </button>
-
-    <nav class:open={isMenuOpen}>
+    <!-- ドロワーメニュー -->
+    <nav class="drawer-menu" aria-label="サイトメニュー">
+        <div class="drawer-header">
+            <img src="{base}/images/icon.png" alt="微小夜行電灯" class="drawer-logo" />
+        </div>
         <ul>
+            <li><a href="{base}/" onclick={closeMenu}>トップ</a></li>
+            <li><a href="{base}/map" onclick={closeMenu}>🏮 屋台貸し出し</a></li>
+            <li><a href="{base}/shop" onclick={closeMenu}>🛒 オンラインストア</a></li>
+            <li><a href="{base}/menu" onclick={closeMenu}>メニュー</a></li>
+            <li><a href="{base}/company" onclick={closeMenu}>事業内容</a></li>
+            <li><a href="{base}/directory" onclick={closeMenu}>夜行人図鑑</a></li>
             <li>
-                <div class="navicon">
-                    <a
-                        href="https://www.instagram.com/delta_yako?igsh=MTYxZmJzZG5yZHZieA%3D%3D&utm_source=qr"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        onclick={closeMenu}
-                    >
-                        <img
-                            src="{base}/images/icon.png"
-                            alt="微小夜行電灯のメニュー一覧用画像"
-                            class="iconmenu"
-                        />
-                    </a>
-                </div>
+                <a
+                    href="https://www.instagram.com/delta_yako?igsh=MTYxZmJzZG5yZHZieA%3D%3D&utm_source=qr"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onclick={closeMenu}
+                >Instagram</a>
             </li>
-            <li>
-                <div class="navbutton">
-                    <a href="{base}/" class="btn" onclick={closeMenu}>微小夜行電灯</a>
-                </div>
-            </li>
-            <li>
-                <div class="navbutton">
-                    <a href="{base}/menu" class="btn" onclick={closeMenu}>メニュー</a>
-                </div>
-            </li>
-            <li>
-                <div class="navbutton">
-                    <a href="{base}/map" class="btn" onclick={closeMenu}>屋台貸し出し</a>
-                </div>
-            </li>
-            <li>
-                <div class="navbutton">
-                    <a href="{base}/shop" class="btn" onclick={closeMenu}>ショップ</a>
-                </div>
-            </li>
-            <li>
-                <div class="navbutton">
-                    <a href="{base}/company" class="btn" onclick={closeMenu}>事業内容</a>
-                </div>
-            </li>
-            <li>
-                <div class="navbutton">
-                    <a href="{base}/directory" class="btn" onclick={closeMenu}>夜行人図鑑</a>
-                </div>
-            </li>
-            <li>
-                <div class="navbutton">
-                    {#if $session}
-                        <button class="btn auth-btn" onclick={handleSignOut}>ログアウト</button>
-                    {:else}
-                        <a href="{base}/auth" class="btn auth-link" onclick={closeMenu}>ログイン / 登録</a>
-                    {/if}
-                </div>
+            <li class="drawer-auth">
+                {#if $session}
+                    <button class="drawer-auth-btn" onclick={handleSignOut}>ログアウト</button>
+                {:else}
+                    <a href="{base}/auth" class="drawer-auth-link" onclick={closeMenu}>ログイン / 新規登録</a>
+                {/if}
             </li>
         </ul>
     </nav>
-</header>
+{/if}
 
 <style>
-    header {
-        margin: 20px;
-    }
-
-    nav {
-        width: 100%;
-        padding: auto;
-    }
-
-    nav ul {
+    /* ========== 共通 ========== */
+    .site-header {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 60px;
+        z-index: 200;
         display: flex;
-        justify-content: space-around;
         align-items: center;
-        list-style-type: none;
-        padding: 0;
-        margin: 0;
+        background: rgba(255, 255, 255, 0.97);
+        backdrop-filter: blur(8px);
+        border-bottom: 1px solid #ede8e0;
+        padding: 0 16px;
+        gap: 12px;
+        box-sizing: border-box;
     }
 
-    nav li {
+    .header-spacer {
+        height: 60px;
+        flex-shrink: 0;
+    }
+
+    /* ロゴ */
+    .logo-link {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        text-decoration: none;
+        color: #26201a;
+        flex-shrink: 0;
+    }
+    .logo-img {
+        width: 36px;
+        height: 36px;
+        object-fit: contain;
+    }
+    .logo-text {
+        font-size: 0.85rem;
+        font-weight: 700;
+        letter-spacing: 0.03em;
+        white-space: nowrap;
+    }
+
+    /* プライマリナビ */
+    .primary-nav {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        margin-left: auto;
+    }
+
+    .primary-nav-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2px;
+        padding: 6px 12px;
+        text-decoration: none;
+        color: #26201a;
+        font-size: 0.7rem;
+        border-radius: 8px;
+        transition: background 0.15s;
+        white-space: nowrap;
+    }
+    .primary-nav-item:hover {
+        background: #f5f0ea;
+    }
+
+    .nav-icon {
+        width: 22px;
+        height: 22px;
+        stroke: #26201a;
+    }
+
+    /* デスクトップ専用リンク（モバイルでは非表示） */
+    .desktop-nav-item {
+        display: none;
+        padding: 8px 12px;
+        text-decoration: none;
+        color: #26201a;
+        font-size: 0.88rem;
+        border-radius: 6px;
+        white-space: nowrap;
+        background: none;
+        border: none;
+        cursor: pointer;
+        font-family: inherit;
+        transition: background 0.15s;
+    }
+    .desktop-nav-item:hover { background: #f5f0ea; }
+    .desktop-auth-link {
+        border: 1.5px solid #26201a;
+        border-radius: 6px;
+        padding: 6px 12px;
+    }
+    .desktop-auth-btn {
+        border: 1.5px solid #26201a;
+        border-radius: 6px;
+        padding: 6px 12px;
+    }
+
+    /* ハンバーガーボタン */
+    .hamburger {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 5px;
+        width: 40px;
+        height: 40px;
+        flex-shrink: 0;
+        cursor: pointer;
+        background: none;
+        border: none;
+        border-radius: 8px;
+        padding: 8px;
+        margin-left: 4px;
+    }
+    .hamburger:hover { background: #f5f0ea; }
+
+    .hamburger span {
+        display: block;
+        width: 20px;
+        height: 2px;
+        background: #26201a;
+        border-radius: 2px;
+        transition: transform 0.25s ease, opacity 0.25s ease;
+        transform-origin: center;
+    }
+    .hamburger.active span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+    .hamburger.active span:nth-child(2) { opacity: 0; transform: scaleX(0); }
+    .hamburger.active span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+
+    /* ========== オーバーレイ ========== */
+    .menu-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 198;
+        background: rgba(0, 0, 0, 0.35);
+    }
+
+    /* ========== ドロワーメニュー ========== */
+    .drawer-menu {
+        position: fixed;
+        top: 0;
+        right: 0;
+        width: min(280px, 80vw);
+        height: 100dvh;
+        background: #fff;
+        z-index: 199;
+        display: flex;
+        flex-direction: column;
+        overflow-y: auto;
+        box-shadow: -4px 0 20px rgba(0, 0, 0, 0.15);
+    }
+
+    .drawer-header {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px 20px 16px;
+        border-bottom: 1px solid #ede8e0;
+    }
+    .drawer-logo {
+        width: 56px;
+        height: 56px;
+        object-fit: contain;
+    }
+
+    .drawer-menu ul {
+        list-style: none;
+        margin: 0;
+        padding: 8px 0;
         flex: 1;
-        margin: 0 20px;
+    }
+    .drawer-menu li {
+        border-bottom: 1px solid #f5f0ea;
+    }
+    .drawer-menu a {
+        display: block;
+        padding: 16px 24px;
+        text-decoration: none;
+        color: #26201a;
+        font-size: 0.95rem;
+        transition: background 0.15s;
+    }
+    .drawer-menu a:hover { background: #faf8f5; }
+
+    .drawer-auth {
+        margin-top: auto;
+        border-bottom: none !important;
+        padding: 16px 24px;
+    }
+    .drawer-auth-btn {
+        width: 100%;
+        padding: 12px;
+        background: none;
+        border: 1.5px solid #26201a;
+        border-radius: 8px;
+        color: #26201a;
+        font-size: 0.95rem;
+        font-family: inherit;
+        cursor: pointer;
+    }
+    .drawer-auth-link {
+        display: block;
+        padding: 12px !important;
+        border: 1.5px solid #26201a !important;
+        border-radius: 8px;
         text-align: center;
     }
 
-    .iconmenu {
-        padding-top: 5px;
-        max-width: 70px;
-        height: auto;
-    }
-
-    .navbutton {
-        text-align: left;
-    }
-
-    .btn {
-        display: block;
-        padding: 10px;
-        text-decoration: none;
-        color: #26201a;
-    }
-
-    .auth-btn {
-        background: none;
-        border: 1.5px solid #26201a;
-        border-radius: 6px;
-        cursor: pointer;
-        font-size: inherit;
-        font-family: inherit;
-        padding: 10px;
-        color: #26201a;
-    }
-
-    .auth-link {
-        border: 1.5px solid #26201a;
-        border-radius: 6px;
-    }
-
-    .hamburger {
-        display: none;
-    }
-
-    .menu-overlay {
-        display: none;
-    }
-
-    @media screen and (max-width: 768px) {
-        /* オーバーレイ */
-        .menu-overlay {
-            display: block;
-            position: fixed;
-            inset: 0;
-            z-index: 998;
-            background: transparent;
+    /* ========== デスクトップ (769px〜) ========== */
+    @media (min-width: 769px) {
+        .site-header {
+            padding: 0 32px;
+            gap: 16px;
         }
 
-        /* ナビゲーション（固定、スクロール影響なし） */
-        nav {
-            display: none;
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100dvh;
-            background-color: rgba(255, 255, 255, 0.97);
-            z-index: 999;
-            overflow-y: auto;
-            padding: 80px 0 40px;
-            box-sizing: border-box;
-            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+        .logo-text { font-size: 1rem; }
+
+        /* デスクトップではアイコン付き2項目 + テキストリンク群を横並び */
+        .primary-nav { gap: 8px; }
+
+        .primary-nav-item {
+            flex-direction: row;
+            gap: 6px;
+            font-size: 0.85rem;
+            padding: 8px 14px;
         }
 
-        nav.open {
-            display: block;
-        }
+        .desktop-nav-item { display: inline-flex; align-items: center; }
 
-        nav ul {
-            flex-direction: column;
-            align-items: stretch;
-        }
-
-        nav li {
-            margin: 0;
-            border-bottom: 1px solid #f0ebe4;
-        }
-
-        .navbutton {
-            text-align: center;
-        }
-
-        .btn {
-            padding: 16px 24px;
-            font-size: 1rem;
-        }
-
-        .navicon {
-            display: flex;
-            justify-content: center;
-            padding: 12px 0;
-        }
-
-        /* ハンバーガーボタン（固定表示） */
-        .hamburger {
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            gap: 5px;
-            position: fixed;
-            top: 16px;
-            right: 16px;
-            width: 44px;
-            height: 44px;
-            z-index: 1000;
-            cursor: pointer;
-            background-color: rgba(255, 255, 255, 0.95);
-            border: none;
-            border-radius: 8px;
-            padding: 10px;
-            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-        }
-
-        .hamburger span {
-            display: block;
-            width: 22px;
-            height: 2px;
-            background-color: #26201a;
-            transition: transform 0.25s ease, opacity 0.25s ease;
-            transform-origin: center;
-        }
-
-        /* ×アイコン（アクティブ時） */
-        .hamburger.active span:nth-child(1) {
-            transform: translateY(7px) rotate(45deg);
-        }
-
-        .hamburger.active span:nth-child(2) {
-            opacity: 0;
-            transform: scaleX(0);
-        }
-
-        .hamburger.active span:nth-child(3) {
-            transform: translateY(-7px) rotate(-45deg);
-        }
+        /* デスクトップではハンバーガーを隠す */
+        .hamburger { display: none; }
     }
 </style>

--- a/src/lib/components/MenuCellView.svelte
+++ b/src/lib/components/MenuCellView.svelte
@@ -3,6 +3,8 @@
 
 	let { menuItem } = $props();
 
+	let isOpen = $state(false);
+
 	function formatMenuPrice(price) {
 		if (price === 0) {
 			return "¥ ---";
@@ -14,7 +16,13 @@
 <div class="menu-cell-container">
 	<div class="menu-image-container">
 		{#if menuItem.image !== ''}
-			<img class="menu-image" src={base + menuItem.image} alt={menuItem.name} />
+			<button
+				class="menu-image-btn"
+				onclick={() => (isOpen = true)}
+				aria-label="{menuItem.name}の写真を拡大"
+			>
+				<img class="menu-image" src={base + menuItem.image} alt={menuItem.name} />
+			</button>
 		{:else}
 			<div class="no-image">NO IMAGE</div>
 		{/if}
@@ -27,6 +35,30 @@
 	</div>
 </div>
 
+{#if isOpen}
+	<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+	<div
+		class="lightbox"
+		role="dialog"
+		aria-modal="true"
+		aria-label="{menuItem.name}の写真"
+		onclick={() => (isOpen = false)}
+		onkeydown={(e) => e.key === 'Escape' && (isOpen = false)}
+		tabindex="-1"
+	>
+		<button class="lightbox-close" onclick={() => (isOpen = false)} aria-label="閉じる">×</button>
+		<img
+			class="lightbox-img"
+			src={base + menuItem.image}
+			alt={menuItem.name}
+		/>
+		<p class="lightbox-caption">
+			<span class="lightbox-name">{@html menuItem.name}</span>
+			<span class="lightbox-price">{formatMenuPrice(menuItem.price)}</span>
+		</p>
+	</div>
+{/if}
+
 <style>
 	.menu-cell-container {
 		width: 100%;
@@ -36,13 +68,24 @@
 	.menu-image-container {
 		width: 100%;
 		margin-bottom: 0.5rem;
-		aspect-ratio: 3 / 4; /* 画像のアスペクト比を4:3に */
+		aspect-ratio: 3 / 4;
+	}
+
+	.menu-image-btn {
+		width: 100%;
+		height: 100%;
+		padding: 0;
+		border: none;
+		background: none;
+		cursor: zoom-in;
+		display: block;
 	}
 
 	.menu-image {
 		width: 100%;
 		height: 100%;
-		object-fit: cover; /* 画像がコンテナにフィットするように */
+		object-fit: cover;
+		display: block;
 		clip-path: polygon(
 			0% 20px,
 			20px 0%,
@@ -72,25 +115,92 @@
 
 	.menu-information {
 		width: 100%;
-		margin:auto;
 		margin-bottom: 1rem;
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 4px;
+		padding: 0 2px;
+		box-sizing: border-box;
 	}
 
 	.menu-title {
-		font-size: 0.9rem;
+		font-size: 0.78rem;
 		color: #26201a;
-		flex-grow: 1; /* タイトルの高さが揃うように調整 */
-		line-height: 34px;
-		text-align: center;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		flex: 1;
+		min-width: 0;
 	}
 
 	.menu-price-container {
-		display: flex;
-		flex-direction: row;
-		justify-content: flex-end;
+		flex-shrink: 0;
 	}
 
 	.menu-price {
-		font-size: 0.8rem;
+		font-size: 0.78rem;
+		white-space: nowrap;
+		color: #26201a;
+		font-weight: 600;
+	}
+
+	/* ライトボックス */
+	.lightbox {
+		position: fixed;
+		inset: 0;
+		z-index: 9999;
+		background: rgba(0, 0, 0, 0.88);
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 20px;
+		box-sizing: border-box;
+	}
+
+	.lightbox-close {
+		position: fixed;
+		top: 16px;
+		right: 16px;
+		width: 40px;
+		height: 40px;
+		border-radius: 50%;
+		border: none;
+		background: rgba(255, 255, 255, 0.2);
+		color: #fff;
+		font-size: 1.4rem;
+		line-height: 1;
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 10000;
+	}
+
+	.lightbox-img {
+		max-width: 100%;
+		max-height: 75svh;
+		border-radius: 12px;
+		object-fit: contain;
+		display: block;
+	}
+
+	.lightbox-caption {
+		margin-top: 16px;
+		display: flex;
+		gap: 16px;
+		align-items: baseline;
+		color: #fff;
+	}
+
+	.lightbox-name {
+		font-size: 1rem;
+		font-weight: 600;
+	}
+
+	.lightbox-price {
+		font-size: 0.9rem;
+		opacity: 0.8;
 	}
 </style>

--- a/src/lib/components/MenuListView.svelte
+++ b/src/lib/components/MenuListView.svelte
@@ -43,15 +43,19 @@
 	}
 
 	.menu-section-container {
-    width: 100%;
-		display: flex;
-		flex-direction: row;
-    gap: 10px;
-		justify-content: flex-start;
-		align-items: flex-start;
+		width: 100%;
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 10px;
 	}
 
-  .menu-cell-container {
-    width: 33.33%;
-  }
+	@media (max-width: 480px) {
+		.menu-section-container {
+			grid-template-columns: repeat(2, 1fr);
+		}
+	}
+
+	.menu-cell-container {
+		width: 100%;
+	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 <script>
 	import ImageSlideshow from '$lib/components/ImageSlideshow.svelte';
 	import SplashView from '$lib/components/SplashView.svelte';
+	import { base } from '$app/paths';
 	import { onMount } from 'svelte';
 
 	import homeData from '$lib/assets/data/home.json';
@@ -68,6 +69,15 @@ let splash = $state();
 
 <SplashView bind:this={splash} />
 
+<section class="hero">
+	<div class="hero-overlay"></div>
+	<div class="hero-content">
+		<h1 class="hero-title">微小夜行電灯</h1>
+		<p class="hero-subtitle">京都・鴨川の屋台シェアリング</p>
+		<a href="{base}/map" class="hero-cta">マップで予約する →</a>
+	</div>
+</section>
+
 <main>
 	<div class="top-gallery-mask" bind:this={gallery} onscroll={onScrollGallery}>
 		<div class="top-gallery">
@@ -100,6 +110,70 @@ let splash = $state();
 </main>
 
 <style>
+	.hero {
+		position: relative;
+		width: 100%;
+		min-height: 70svh;
+		background-image: url('/images/back_yatai_road.png');
+		background-size: cover;
+		background-position: center;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		overflow: hidden;
+	}
+
+	.hero-overlay {
+		position: absolute;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.45);
+	}
+
+	.hero-content {
+		position: relative;
+		z-index: 1;
+		text-align: center;
+		color: #fff;
+		padding: 0 24px;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 16px;
+	}
+
+	.hero-title {
+		font-size: clamp(2rem, 8vw, 3.5rem);
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		line-height: 1.2;
+		text-shadow: 0 2px 12px rgba(0, 0, 0, 0.5);
+	}
+
+	.hero-subtitle {
+		font-size: clamp(0.9rem, 3vw, 1.2rem);
+		letter-spacing: 0.05em;
+		opacity: 0.9;
+	}
+
+	.hero-cta {
+		display: inline-block;
+		margin-top: 8px;
+		padding: 14px 32px;
+		background: #d56d04;
+		color: #fff;
+		text-decoration: none;
+		border-radius: 100px;
+		font-size: 1rem;
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+		transition: background 0.2s;
+	}
+
+	.hero-cta:hover {
+		background: #b85c03;
+	}
+
 	main {
 		width: 100%;
 		box-sizing: border-box;

--- a/src/routes/company/+page.svelte
+++ b/src/routes/company/+page.svelte
@@ -7,9 +7,13 @@
 	let imageModalView = $state();
 </script>
 
+<div class="company-hero">
+	<div class="company-hero-overlay"></div>
+	<h1 class="company-hero-title">事業内容</h1>
+</div>
+
 <main>
 	<div class="summary-container">
-		<h1 class="summary-name">事業内容</h1>
 		<p class="summary">{company.summary}</p>
 	</div>
 
@@ -34,18 +38,44 @@
 </main>
 
 <style>
+	.company-hero {
+		position: relative;
+		width: 100%;
+		height: 260px;
+		background-image: url('/images/shop/yatai.jpg');
+		background-size: cover;
+		background-position: center;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		overflow: hidden;
+	}
+
+	.company-hero-overlay {
+		position: absolute;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+	}
+
+	.company-hero-title {
+		position: relative;
+		z-index: 1;
+		color: #fff;
+		font-size: 2rem;
+		letter-spacing: 0.15em;
+		text-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+		margin: 0;
+	}
+
 	main {
 		max-width: 15cm;
 		margin: auto;
+		padding: 0 20px;
 	}
 
 	.summary-container {
+		margin-top: 2.5rem;
 		margin-bottom: 3rem;
-	}
-
-	.summary-name {
-		text-align: center;
-		margin-bottom: 1.5rem;
 	}
 
 	.business-container {

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -354,7 +354,8 @@
 		reservationItems = myMenuItems.map((m) => ({
 			name: m.name,
 			price: m.price ?? 0,
-			description: m.description ?? ''
+			description: m.description ?? '',
+			photoUrl: m.photo_path ?? ''
 		}));
 	}
 
@@ -386,7 +387,8 @@
 			? JSON.stringify(validItems.map((i) => ({
 				name: i.name.trim(),
 				price: parseInt(String(i.price)) || 0,
-				description: i.description?.trim() || ''
+				description: i.description?.trim() || '',
+				photoUrl: i.photoUrl?.trim() || ''
 			})))
 			: null;
 
@@ -432,11 +434,12 @@
 				return parsed
 					.map((i) =>
 						typeof i === 'string'
-							? { name: i, price: 0, description: '' }
+							? { name: i, price: 0, description: '', photoUrl: '' }
 							: {
 									name: String(i.name || ''),
 									price: Number(i.price) || 0,
-									description: String(i.description || '')
+									description: String(i.description || ''),
+									photoUrl: String(i.photoUrl || '')
 								}
 					)
 					.filter((i) => i.name);
@@ -764,7 +767,7 @@
 										<div class="active-menu-list">
 											<p class="active-menu-label">本日のメニュー</p>
 											{#each activeItems as item}
-												{@const photoUrl = selectedStall.menuPhotoMap?.[item.name] ?? null}
+												{@const photoUrl = item.photoUrl || selectedStall.menuPhotoMap?.[item.name] || null}
 												<div class="active-menu-item">
 													{#if photoUrl}
 														<button
@@ -1138,12 +1141,12 @@
 	:global(body) { margin: 0; padding: 0; font-family: sans-serif; }
 
 	.app-container {
-		width: 100%; height: 100vh;
+		width: 100%; height: calc(100svh - 60px);
 		display: flex; flex-direction: column;
 		background: #f1f5f9; position: relative; overflow: hidden;
 	}
 
-	.app-header { position: absolute; top: 80px; right: 20px; z-index: 10; }
+	.app-header { position: absolute; top: 16px; right: 16px; z-index: 10; }
 
 	.toggle-switch {
 		background: white; border-radius: 30px; padding: 4px;

--- a/src/routes/menu/+page.svelte
+++ b/src/routes/menu/+page.svelte
@@ -12,7 +12,9 @@
 
 <style>
 	main {
-    max-width: 15cm;
-    margin: auto;
+		max-width: 15cm;
+		margin: auto;
+		padding: 0 20px;
+		box-sizing: border-box;
 	}
 </style>

--- a/static/global.css
+++ b/static/global.css
@@ -5,7 +5,7 @@ body {
   background-color: #fbf3ea;
   color: #26201a;
   margin: 0;
-  padding: 20px;
+  padding: 0;
 }
 
 .display-font {


### PR DESCRIPTION
… photo lightbox

- Add hero image + CTA button to top page
- Add hero banner to company page
- Redesign header: primary nav items (map/shop) always visible with icons, others in drawer
- Fix mobile menu: show key items outside hamburger like Tully's Coffee
- Make menu grid responsive (3col desktop / 2col mobile)
- Add photo lightbox to MenuCellView on click
- Fix menu item name+price layout (no-wrap, same line)
- Remove body padding; each page manages own spacing
- Map page: adjust height for fixed header (calc 100svh-60px)
- Embed photoUrl in planned_items JSON for reliable photo display